### PR TITLE
Restore default page size and options in FoodOverviewPage

### DIFF
--- a/src/app/(landing)/[lng]/food-management/partials/FoodOverviewPage.tsx
+++ b/src/app/(landing)/[lng]/food-management/partials/FoodOverviewPage.tsx
@@ -97,7 +97,7 @@ export default function FoodOverviewPage(): React.ReactElement {
   const token = session?.apiToken
 
   const [page, setPage] = useState(1)
-  const [pageSize, setPageSize] = useState(600) // TODO: change back to 10 once properly fixed
+  const [pageSize, setPageSize] = useState(10)
   const [openAddFoodPopUp, setOpenAddFoodPopUp] = useState(false)
   const [foods, setFoods] = useState<FoodOverviewDataType[]>([])
   const [isLoading, setIsLoading] = useState(false)
@@ -608,8 +608,7 @@ export default function FoodOverviewPage(): React.ReactElement {
           page={page}
           pageSize={pageSize}
           totalItems={totalCount}
-          // TODO: remove 600 once quick fix is not needed
-          pageSizeOptions={[5, 10, 20, 600]}
+          pageSizeOptions={[5, 10, 20]}
           onPageChange={setPage}
           onPageSizeChange={size => {
             setPageSize(size)


### PR DESCRIPTION
Set the initial page size back to 10 and removed the temporary 600 option